### PR TITLE
Fix web automation docstrings and task logging

### DIFF
--- a/libs/web/__init__.py
+++ b/libs/web/__init__.py
@@ -233,7 +233,7 @@ class WebAutomationBase(ABC):
         raise NotImplementedError()
 
     def close(self) -> None:
-        """Logs out and then closes the browser.
+        """Logs out and then closes the browser page.
 
         Note: the browser and the context are not closed as required
         by the robocorp-browser framework, see that package for
@@ -254,5 +254,6 @@ class WebAutomationBase(ABC):
         return self
 
     def __exit__(self, exc_type, exc_value, traceback) -> None:
-        """Exit the context manager. This will close the browser instance."""
+        """Exit the context manager. This will close the page managed
+        by the browser library."""
         self.close()

--- a/tasks/__init__.py
+++ b/tasks/__init__.py
@@ -10,7 +10,7 @@ ROBOT_ROOT = Path(__file__).parent.parent
 DEVDATA = ROBOT_ROOT / "devdata"
 
 
-def _setup_log() -> None:
+def setup_log() -> None:
     """Tries to use the LOG_LEVEL text asset or environment variable
     to set the log level. If the value is not valid, the default is
     "info". The environment variable will override the asset value.
@@ -27,7 +27,7 @@ def _setup_log() -> None:
     log.setup_log(output_log_level=log_level)
 
 
-def _get_secret(system: str) -> vault.SecretContainer:
+def get_secret(system: str) -> vault.SecretContainer:
     """Gets the appropriate secret from the vault based on
     the system name and the mapping within the Control Room
     asset storage. This is a simple example of how you can
@@ -63,4 +63,4 @@ def _get_secret(system: str) -> vault.SecretContainer:
     return vault.get_secret(secret_name)
 
 
-__all__ = ["ARTIFACTS_DIR", "ROBOT_ROOT", "DEVDATA", "_setup_log", "_get_secret"]
+__all__ = ["ARTIFACTS_DIR", "ROBOT_ROOT", "DEVDATA", "setup_log", "get_secret"]

--- a/tasks/consumer_tasks.py
+++ b/tasks/consumer_tasks.py
@@ -5,7 +5,7 @@ well as the robocorp.log facility to log additional information.
 from robocorp import log, workitems
 from robocorp.tasks import task
 
-from . import _setup_log, _get_secret
+from . import setup_log, get_secret
 
 from libs.web.swaglabs import Swaglabs
 
@@ -13,7 +13,7 @@ from libs.web.swaglabs import Swaglabs
 INPUT_FILE_NAME = "orders.csv"
 
 
-def _process_order(swaglabs: Swaglabs, work_item: workitems.Input) -> None:
+def process_order(swaglabs: Swaglabs, work_item: workitems.Input) -> None:
     """Processes an order (a single work item).
 
     Args:
@@ -53,14 +53,14 @@ def _process_order(swaglabs: Swaglabs, work_item: workitems.Input) -> None:
 
 @task
 def consumer():
-    _setup_log()
+    setup_log()
     log.info("Consumer task started.")
-    credentials = _get_secret("swaglabs")
+    credentials = get_secret("swaglabs")
     with Swaglabs(
         credentials["username"], credentials["password"], credentials["url"]
     ) as swaglabs:
         # This loop is the most important in the Consumer.
         for work_item in workitems.inputs:
             with work_item:
-                _process_order(swaglabs, work_item)
+                process_order(swaglabs, work_item)
             log.info(f"Work item was released with state '{work_item.state}'.")

--- a/tasks/producer_tasks.py
+++ b/tasks/producer_tasks.py
@@ -8,7 +8,7 @@ from robocorp import log, workitems, excel
 from robocorp.tasks import task
 from robocorp.excel import tables
 
-from . import ARTIFACTS_DIR, _setup_log
+from . import ARTIFACTS_DIR, setup_log
 
 
 INPUT_FILE_NAME = "orders.csv"
@@ -16,7 +16,7 @@ INPUT_FILE_NAME = "orders.csv"
 
 @task
 def producer():
-    _setup_log()
+    setup_log()
     log.info("Producer task started.")
 
     # Often times, a producer bot needs to go get work items from

--- a/tasks/reporter_tasks.py
+++ b/tasks/reporter_tasks.py
@@ -6,7 +6,7 @@ from datetime import datetime
 from robocorp import log, workitems
 from robocorp.tasks import task
 
-from . import ARTIFACTS_DIR, DEVDATA, _setup_log
+from . import ARTIFACTS_DIR, DEVDATA, setup_log
 
 
 @task
@@ -27,7 +27,7 @@ def reporter():
     Alternatively, you could save the results to a file or generate
     an email or other notification.
     """
-    _setup_log()
+    setup_log()
     log.info("Reporter task started.")
 
     # The final output work item should be created first, because


### PR DESCRIPTION
Fix `close` method and `__exit__` method docstring in `WebAutomation` base class.

Also, fix logging for functions marked private because of leading `_`.